### PR TITLE
Faster loading of SAS files from high latency media.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.loader
 Type: Package
 Title: Data loading module 
-Version: 2.1.0
+Version: 2.1.0-9000
 Authors@R: c(
         person( "Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person( given = "Ming", family = "Yang", role = c("aut", "cre"), email = "ming.yang.ext@boehringer-ingelheim.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.loader 2.1.0-9000
+
+- Faster loading of large SAS files from high latency media (e.g. network shares).
+
 # dv.loader 2.1.0
 
 - Added `load_files()` to load data using explicit file paths.

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,17 +57,20 @@ create_data_list <- function(file_path, file_names, prefer_sas) {
 #'
 #' @keywords internal
 read_file_and_attach_metadata <- function(path) {
+  meta <- file.info(path, extra_cols = FALSE)
   extension <- tools::file_ext(path)
 
   if (toupper(extension) == "RDS") {
     data <- readRDS(path)
   } else if (toupper(extension) == "SAS7BDAT") {
+    # Preload file into OS file cache to get faster loads on high-latency media (e.g. network shares)
+    readBin(path, raw(), meta[["size"]]) # The return value goes unasigned on purpose
+
     data <- haven::read_sas(path)
   } else {
     stop("Not supported file type, only .rds or .sas7bdat files can be loaded.")
   }
 
-  meta <- file.info(path, extra_cols = FALSE)
   meta[["path"]] <- path
   meta[["file_name"]] <- basename(path)
   row.names(meta) <- NULL


### PR DESCRIPTION
The faster loading is accomplished by reading the entire file sequentially (the `readBin` call) and ignoring the result. That still copies the contents of the file in the OS file cache, which is faster than the haphazard jumping around that `haven` parsing does. Next, we ask for the contents of the file, but this time through `haven`. The OS has little opportunity to evict the contents of the file from the cache as both read calls happen in close succession.

We've considered the possibility of using the output of the `readBin` call as the input to `haven::load_sas`, but that generates an extra in-memory copy of the file contents and no apparent speed benefit. 

# Hotfix checklist

- [x] Bumped minor version number on both DESCRIPTION and NEWS.md

- [x] Build passes pipeline checks

- [x] The new changes do not affect the API

- [x] The new changes do not affect the documentation (including screenshots)

- [x] The new changes do not impact the QC report